### PR TITLE
Extend fixed length of prices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,12 +1,12 @@
-import React, { useEffect } from 'react'
-import './App.css'
-import { ApolloClient } from 'apollo-client'
-import { InMemoryCache } from 'apollo-cache-inmemory'
-import { HttpLink } from 'apollo-link-http'
-import { useQuery } from '@apollo/react-hooks'
-import gql from 'graphql-tag'
-import uniswapLogo from '../uniswap-logo.png'
-import daiLogo from '../dai-logo.png'
+import React, { useEffect } from 'react';
+import './App.css';
+import { ApolloClient } from 'apollo-client';
+import { InMemoryCache } from 'apollo-cache-inmemory';
+import { HttpLink } from 'apollo-link-http';
+import { useQuery } from '@apollo/react-hooks';
+import gql from 'graphql-tag';
+import uniswapLogo from '../uniswap-logo.png';
+import daiLogo from '../dai-logo.png';
 
 export const client = new ApolloClient({
   link: new HttpLink({
@@ -16,7 +16,7 @@ export const client = new ApolloClient({
     mode: 'no-cors'
   },
   cache: new InMemoryCache()
-})
+});
 
 const DAI_QUERY = gql`
   query tokens($tokenAddress: Bytes!) {
@@ -25,7 +25,7 @@ const DAI_QUERY = gql`
       totalLiquidity
     }
   }
-`
+`;
 
 const ETH_PRICE_QUERY = gql`
   query bundles {
@@ -33,19 +33,19 @@ const ETH_PRICE_QUERY = gql`
       ethPrice
     }
   }
-`
+`;
 
 function App() {
-  const { loading: ethLoading, data: ethPriceData } = useQuery(ETH_PRICE_QUERY)
+  const { loading: ethLoading, data: ethPriceData } = useQuery(ETH_PRICE_QUERY);
   const { loading: daiLoading, data: daiData } = useQuery(DAI_QUERY, {
     variables: {
       tokenAddress: '0x6b175474e89094c44da98b954eedeac495271d0f'
     }
-  })
+  });
 
-  const daiPriceInEth = daiData && daiData.tokens[0].derivedETH
-  const daiTotalLiquidity = daiData && daiData.tokens[0].totalLiquidity
-  const ethPriceInUSD = ethPriceData && ethPriceData.bundles[0].ethPrice
+  const daiPriceInEth = daiData && daiData.tokens[0].derivedETH;
+  const daiTotalLiquidity = daiData && daiData.tokens[0].totalLiquidity;
+  const ethPriceInUSD = ethPriceData && ethPriceData.bundles[0].ethPrice;
 
   return (
     <div>
@@ -56,7 +56,13 @@ function App() {
           target="_blank"
           rel="noopener noreferrer"
         >
-          <img src={uniswapLogo} width="30" height="30" className="d-inline-block align-top" alt="" />
+          <img
+            src={uniswapLogo}
+            width="30"
+            height="30"
+            className="d-inline-block align-top"
+            alt=""
+          />
           &nbsp; Uniswap Explorer
         </a>
       </nav>
@@ -65,21 +71,31 @@ function App() {
           <main role="main" className="col-lg-12 d-flex text-center">
             <div className="content mr-auto ml-auto">
               <div>
-                <img src={daiLogo} width="150" height="150" className="mb-4" alt="" />
+                <img
+                  src={daiLogo}
+                  width="150"
+                  height="150"
+                  className="mb-4"
+                  alt=""
+                />
                 <h2>
                   Dai price:{' '}
                   {ethLoading || daiLoading
                     ? 'Loading token data...'
                     : '$' +
                       // parse responses as floats and fix to 2 decimals
-                      (parseFloat(daiPriceInEth) * parseFloat(ethPriceInUSD)).toFixed(2)}
+                      (
+                        parseFloat(daiPriceInEth) * parseFloat(ethPriceInUSD)
+                      ).toFixed(8)}
                 </h2>
                 <h2>
                   Dai total liquidity:{' '}
                   {daiLoading
                     ? 'Loading token data...'
                     : // display the total amount of DAI spread across all pools
-                      parseFloat(daiTotalLiquidity).toFixed(0)}
+                      Number(
+                        parseFloat(daiTotalLiquidity).toFixed(0)
+                      ).toLocaleString()}
                 </h2>
               </div>
             </div>
@@ -90,4 +106,4 @@ function App() {
   );
 }
 
-export default App
+export default App;


### PR DESCRIPTION
The amount of significant digits is much more than 1/100th like we have with pennies. This change introduces this as well as locale-split commas (or `.` on the total supply number)

<img width="536" alt="Screen Shot 2022-05-16 at 10 47 54 PM" src="https://user-images.githubusercontent.com/3408480/168718332-aa9cc023-3de5-4975-a01d-fcaf1692ddb3.png">
